### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Or, please contact using function of the such as github pull request.
    :target: http://travis-ci.org/mtoshi/sysdescrparser
 .. image:: https://coveralls.io/repos/mtoshi/sysdescrparser/badge.svg?branch=master
    :target: https://coveralls.io/r/mtoshi/sysdescrparser?branch=master
-.. image:: https://pypip.in/version/sysdescrparser/badge.svg
+.. image:: https://img.shields.io/pypi/v/sysdescrparser.svg
    :target: https://pypi.python.org/pypi/sysdescrparser/
    :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20sysdescrparser))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `sysdescrparser`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.