### PR TITLE
add support for additional A10, Arista, Juniper devices

### DIFF
--- a/sysdescrparser/a10_acos.py
+++ b/sysdescrparser/a10_acos.py
@@ -25,8 +25,8 @@ class A10ACOS(A10):
 
     def parse(self):
         """Parse."""
-        regex = (r'^AX\s+Series\s+Advanced\s+Traffic\s+Manager\s+(.*),\s+'
-                 r'.*\s+version\s+(.*),')
+        regex = (r'^(?:AX\s+Series\s+Advanced\s+Traffic\s+Manager|Thunder\s+Series\s+Unified\s+Application\s+Service\s+Gateway)\s+(.*),(?:\s+|)'
+                 r'.*\s+(?:version|ACOS)\s+(.*),')
         pat = re.compile(regex)
         res = pat.search(self.raw)
         if res:

--- a/sysdescrparser/arista_eos.py
+++ b/sysdescrparser/arista_eos.py
@@ -27,7 +27,7 @@ class AristaEOS(Arista):
         """Parse."""
         regex = (r'Arista\s+Networks\s+EOS\s+'
                  r'version\s+(.*)\s+'
-                 r'running\s+on\s+an\s+Arista\s+Networks\s+(.*)$')
+                 r'running\s+on\s+(?:an\s+Arista\s+Networks|a)\s+(.*)$')
         pat = re.compile(regex)
         res = pat.search(self.raw)
         if res:

--- a/sysdescrparser/juniper_junos.py
+++ b/sysdescrparser/juniper_junos.py
@@ -26,7 +26,7 @@ class JuniperJunos(Juniper):
     def parse(self):
         """Parse."""
         regex = (r'Juniper\s+Networks,\s+Inc.'
-                 r'\s+(.*)\s+internet\s+router,\s+kernel\s+JUNOS\s+(.*) #')
+                 r'\s+(.*)\s+(?:internet\s+router|Ethernet\sSwitch),\s+kernel\s+JUNOS\s+([A-Z0-9-.]*)(?:\s#|,\s)')
         pat = re.compile(regex)
         res = pat.search(self.raw)
         if res:


### PR DESCRIPTION
Very useful utility, found a few new devices.  Thanks!

Thunder Series Unified Application Service Gateway TH3430, ACOS 4.0.3-P4,
Arista Networks EOS version 4.21.3F-2GB running on a  DCS-7050QX-32
Juniper Networks, Inc. mx960 internet router, kernel JUNOS 15.1X12, Build date: 2018-05-02 08:11:56 UTC Copyright (c) 1996-2018 Juniper Networks, Inc.
Juniper Networks, Inc. qfx10002-36q Ethernet Switch, kernel JUNOS 15.1X53-D67.5, Build date: 2018-06-19 22:20:33 UTC Copyright (c) 1996-2018 Juniper Networks, Inc.